### PR TITLE
fix: update ScrapingRobot API requests

### DIFF
--- a/scrapers/services/scrapingrobot.ts
+++ b/scrapers/services/scrapingrobot.ts
@@ -1,16 +1,41 @@
-const scrapingRobot:ScraperSettings = {
-   id: 'scrapingrobot',
-   name: 'Scraping Robot',
-   website: 'scrapingrobot.com',
-   scrapeURL: (keyword, settings, countryData, pagination) => {
-      const country = keyword.country || 'US';
-      const device = keyword.device === 'mobile' ? '&mobile=true' : '';
-      const lang = countryData[country][2];
-      const p = pagination || { start: 0, num: 10 };
-      const url = encodeURI(`https://www.google.com/search?num=${p.num}&start=${p.start}&hl=${lang}&gl=${country}&q=${keyword.keyword}`);
-      return `https://api.scrapingrobot.com/?token=${settings.scaping_api}&proxyCountry=${country}&render=false${device}&url=${url}`;
-   },
-   resultObjectKey: 'result',
+const scrapingRobot: ScraperSettings = {
+  id: "scrapingrobot",
+  name: "Scraping Robot",
+  website: "scrapingrobot.com",
+  scrapeURL: (_keyword, settings) => {
+    return `https://api.scrapingrobot.com/?token=${settings.scaping_api}`;
+  },
+  requestOptions: (keyword, _settings, countryData, pagination) => {
+    const country = keyword.country || "US";
+    const lang = countryData[country][2];
+    const p = pagination || { start: 0, num: 10 };
+    const searchParams = new URLSearchParams({
+      num: `${p.num}`,
+      start: `${p.start}`,
+      hl: lang,
+      gl: country,
+      q: keyword.keyword,
+    });
+    const payload: Record<string, string | boolean> = {
+      url: `https://www.google.com/search?${searchParams.toString()}`,
+      module: "HtmlRequestScraper",
+      proxyCountry: country,
+      render: false,
+    };
+
+    if (keyword.device === "mobile") {
+      payload.mobile = true;
+    }
+
+    return {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    };
+  },
+  resultObjectKey: "result",
 };
 
 export default scrapingRobot;

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,273 +1,290 @@
 /* eslint-disable no-unused-vars */
-type ScrapeStrategy = 'basic' | 'custom' | 'smart'
+type ScrapeStrategy = "basic" | "custom" | "smart";
 
 type DomainType = {
-   ID: number,
-   domain: string,
-   slug: string,
-   tags?: string,
-   notification: boolean,
-   notification_interval: string,
-   notification_emails: string,
-   lastUpdated: string,
-   added: string,
-   keywordCount?: number,
-   keywordsUpdated?: string,
-   avgPosition?: number,
-   scVisits?: number,
-   scImpressions?: number,
-   scPosition?: number,
-   search_console?: string,
-   ideas_settings?: string,
-   scrape_strategy?: ScrapeStrategy | '',
-   scrape_pagination_limit?: number,
-   scrape_smart_full_fallback?: boolean,
-}
+  ID: number;
+  domain: string;
+  slug: string;
+  tags?: string;
+  notification: boolean;
+  notification_interval: string;
+  notification_emails: string;
+  lastUpdated: string;
+  added: string;
+  keywordCount?: number;
+  keywordsUpdated?: string;
+  avgPosition?: number;
+  scVisits?: number;
+  scImpressions?: number;
+  scPosition?: number;
+  search_console?: string;
+  ideas_settings?: string;
+  scrape_strategy?: ScrapeStrategy | "";
+  scrape_pagination_limit?: number;
+  scrape_smart_full_fallback?: boolean;
+};
 
 type KeywordHistory = {
-   [date:string] : number
-}
+  [date: string]: number;
+};
 
 type KeywordType = {
-   ID: number,
-   keyword: string,
-   device: string,
-   country: string,
-   domain: string,
-   lastUpdated: string,
-   added: string,
-   position: number,
-   volume: number,
-   sticky: boolean,
-   history: KeywordHistory,
-   lastResult: KeywordLastResult[],
-   url: string,
-   tags: string[],
-   updating: boolean,
-   lastUpdateError: {date: string, error: string, scraper: string} | false,
-   scData?: KeywordSCData,
-   uid?: string
-   city?: string
-}
+  ID: number;
+  keyword: string;
+  device: string;
+  country: string;
+  domain: string;
+  lastUpdated: string;
+  added: string;
+  position: number;
+  volume: number;
+  sticky: boolean;
+  history: KeywordHistory;
+  lastResult: KeywordLastResult[];
+  url: string;
+  tags: string[];
+  updating: boolean;
+  lastUpdateError: { date: string; error: string; scraper: string } | false;
+  scData?: KeywordSCData;
+  uid?: string;
+  city?: string;
+};
 
 type KeywordLastResult = {
-   position: number,
-   url: string,
-   title: string,
-   skipped?: boolean
-}
+  position: number;
+  url: string;
+  title: string;
+  skipped?: boolean;
+};
 
 type KeywordFilters = {
-   countries: string[],
-   tags: string[],
-   search: string,
-}
+  countries: string[];
+  tags: string[];
+  search: string;
+};
 
 type countryData = {
-   [ISO:string] : [countryName:string, cityName:string, language:string, AdWordsID: number]
-}
+  [ISO: string]: [
+    countryName: string,
+    cityName: string,
+    language: string,
+    AdWordsID: number
+  ];
+};
 
 type countryCodeData = {
-   [ISO:string] : string
-}
+  [ISO: string]: string;
+};
 
 type DomainSearchConsole = {
-   property_type: 'domain' | 'url',
-   url: string,
-   client_email:string,
-   private_key:string,
-}
+  property_type: "domain" | "url";
+  url: string;
+  client_email: string;
+  private_key: string;
+};
 
 type DomainSettings = {
-   notification_interval: string,
-   notification_emails: string,
-   search_console?: DomainSearchConsole,
-   scrape_strategy?: ScrapeStrategy | '',
-   scrape_pagination_limit?: number,
-   scrape_smart_full_fallback?: boolean,
-}
+  notification_interval: string;
+  notification_emails: string;
+  search_console?: DomainSearchConsole;
+  scrape_strategy?: ScrapeStrategy | "";
+  scrape_pagination_limit?: number;
+  scrape_smart_full_fallback?: boolean;
+};
 
 type SettingsType = {
-   scraper_type: string,
-   scaping_api?: string,
-   proxy?: string,
-   notification_interval: string,
-   notification_email: string,
-   notification_email_from: string,
-   notification_email_from_name: string,
-   smtp_server: string,
-   smtp_port: string,
-   smtp_username?: string,
-   smtp_password?: string,
-   available_scrapers?: { label: string, value: string, allowsCity?: boolean }[],
-   scrape_interval?: string,
-   scrape_delay?: string,
-   scrape_retry?: boolean,
-   scrape_strategy?: ScrapeStrategy,
-   scrape_pagination_limit?: number,
-   scrape_smart_full_fallback?: boolean,
-   failed_queue?: string[]
-   version?: string,
-   screenshot_key?: string,
-   search_console: boolean,
-   search_console_client_email: string,
-   search_console_private_key: string,
-   search_console_integrated?: boolean,
-   adwords_client_id?: string,
-   adwords_client_secret?: string,
-   adwords_refresh_token?: string,
-   adwords_developer_token?: string,
-   adwords_account_id?: string,
-   keywordsColumns: string[]
-}
+  scraper_type: string;
+  scaping_api?: string;
+  proxy?: string;
+  notification_interval: string;
+  notification_email: string;
+  notification_email_from: string;
+  notification_email_from_name: string;
+  smtp_server: string;
+  smtp_port: string;
+  smtp_username?: string;
+  smtp_password?: string;
+  available_scrapers?: { label: string; value: string; allowsCity?: boolean }[];
+  scrape_interval?: string;
+  scrape_delay?: string;
+  scrape_retry?: boolean;
+  scrape_strategy?: ScrapeStrategy;
+  scrape_pagination_limit?: number;
+  scrape_smart_full_fallback?: boolean;
+  failed_queue?: string[];
+  version?: string;
+  screenshot_key?: string;
+  search_console: boolean;
+  search_console_client_email: string;
+  search_console_private_key: string;
+  search_console_integrated?: boolean;
+  adwords_client_id?: string;
+  adwords_client_secret?: string;
+  adwords_refresh_token?: string;
+  adwords_developer_token?: string;
+  adwords_account_id?: string;
+  keywordsColumns: string[];
+};
 
 type KeywordSCDataChild = {
-   yesterday: number,
-   threeDays: number,
-   sevenDays: number,
-   thirtyDays: number,
-   avgSevenDays: number,
-   avgThreeDays: number,
-   avgThirtyDays: number,
-}
+  yesterday: number;
+  threeDays: number;
+  sevenDays: number;
+  thirtyDays: number;
+  avgSevenDays: number;
+  avgThreeDays: number;
+  avgThirtyDays: number;
+};
 type KeywordSCData = {
-   impressions: KeywordSCDataChild,
-   visits: KeywordSCDataChild,
-   ctr: KeywordSCDataChild,
-   position:KeywordSCDataChild
-}
+  impressions: KeywordSCDataChild;
+  visits: KeywordSCDataChild;
+  ctr: KeywordSCDataChild;
+  position: KeywordSCDataChild;
+};
 
 type KeywordAddPayload = {
-   keyword: string,
-   device: string,
-   country: string,
-   domain: string,
-   tags?: string,
-   city?:string
-}
+  keyword: string;
+  device: string;
+  country: string;
+  domain: string;
+  tags?: string;
+  city?: string;
+};
 
 type SearchAnalyticsRawItem = {
-   keys: string[],
-   clicks: number,
-   impressions: number,
-   ctr: number,
-   position: number,
-}
+  keys: string[];
+  clicks: number;
+  impressions: number;
+  ctr: number;
+  position: number;
+};
 
 type SearchAnalyticsStat = {
-   date: string,
-   clicks: number,
-   impressions: number,
-   ctr: number,
-   position: number,
-}
+  date: string;
+  clicks: number;
+  impressions: number;
+  ctr: number;
+  position: number;
+};
 
 type InsightDataType = {
-   stats: SearchAnalyticsStat[]|null,
-   keywords: SCInsightItem[],
-   countries: SCInsightItem[],
-   pages: SCInsightItem[],
-}
+  stats: SearchAnalyticsStat[] | null;
+  keywords: SCInsightItem[];
+  countries: SCInsightItem[];
+  pages: SCInsightItem[];
+};
 
 type SCInsightItem = {
-   clicks: number,
-   impressions: number,
-   ctr: number,
-   position: number,
-   countries?: number,
-   country?: string,
-   keyword?: string,
-   keywords?: number,
-   page?: string,
-   date?: string
-}
+  clicks: number;
+  impressions: number;
+  ctr: number;
+  position: number;
+  countries?: number;
+  country?: string;
+  keyword?: string;
+  keywords?: number;
+  page?: string;
+  date?: string;
+};
 
 type SearchAnalyticsItem = {
-   keyword: string,
-   uid: string,
-   device: string,
-   page: string,
-   country: string,
-   clicks: number,
-   impressions: number,
-   ctr: number,
-   position: number,
-   date?: string
-}
+  keyword: string;
+  uid: string;
+  device: string;
+  page: string;
+  country: string;
+  clicks: number;
+  impressions: number;
+  ctr: number;
+  position: number;
+  date?: string;
+};
 
 type SCDomainDataType = {
-   threeDays : SearchAnalyticsItem[],
-   sevenDays : SearchAnalyticsItem[],
-   thirtyDays : SearchAnalyticsItem[],
-   lastFetched?: string,
-   lastFetchError?: string,
-   stats? : SearchAnalyticsStat[],
-}
+  threeDays: SearchAnalyticsItem[];
+  sevenDays: SearchAnalyticsItem[];
+  thirtyDays: SearchAnalyticsItem[];
+  lastFetched?: string;
+  lastFetchError?: string;
+  stats?: SearchAnalyticsStat[];
+};
 
 type SCKeywordType = SearchAnalyticsItem;
 
 type DomainIdeasSettings = {
-   seedSCKeywords: boolean,
-   seedCurrentKeywords: boolean,
-   seedDomain: boolean,
-   language: string,
-   countries: string[],
-   keywords: string
-}
+  seedSCKeywords: boolean;
+  seedCurrentKeywords: boolean;
+  seedDomain: boolean;
+  language: string;
+  countries: string[];
+  keywords: string;
+};
 
 type AdwordsCredentials = {
-   client_id: string,
-   client_secret: string,
-   developer_token: string,
-   account_id: string,
-   refresh_token: string,
-}
+  client_id: string;
+  client_secret: string;
+  developer_token: string;
+  account_id: string;
+  refresh_token: string;
+};
 
 type IdeaKeyword = {
-   uid: string,
-   keyword: string,
-   competition: 'UNSPECIFIED' | 'UNKNOWN' | 'HIGH' | 'LOW' | 'MEDIUM',
-   country: string,
-   domain: string,
-   competitionIndex : number,
-   monthlySearchVolumes: Record<string, string>,
-   avgMonthlySearches: number,
-   added: number,
-   updated: number,
-   position:number
-}
+  uid: string;
+  keyword: string;
+  competition: "UNSPECIFIED" | "UNKNOWN" | "HIGH" | "LOW" | "MEDIUM";
+  country: string;
+  domain: string;
+  competitionIndex: number;
+  monthlySearchVolumes: Record<string, string>;
+  avgMonthlySearches: number;
+  added: number;
+  updated: number;
+  position: number;
+};
 
 type scraperExtractedItem = {
-   title: string,
-   url: string,
-   position: number,
-}
+  title: string;
+  url: string;
+  position: number;
+};
 type ScraperPagination = {
-   start: number,
-   num: number,
-   page: number,
-}
+  start: number;
+  num: number;
+  page: number;
+};
 
 interface ScraperSettings {
-   /** A Unique ID for the Scraper. eg: myScraper */
-   id:string,
-   /** The Name of the Scraper */
-   name:string,
-   /** The Website address of the Scraper */
-   website:string,
-   /** The result object's key that contains the results of the scraped data. For example,
-    * if your scraper API the data like this `{scraped:[item1,item2..]}` the resultObjectKey should be "scraped" */
-   resultObjectKey: string,
-   /** If the Scraper allows setting a precise location or allows city level scraping set this to true. */
-   allowsCity?: boolean,
-   /** Whether this scraper API handles its own pagination (e.g. num=100) and should bypass the app's pagination logic */
-   nativePagination?: boolean,
-   /** Set your own custom HTTP header properties when making the scraper API request.
-    * The function should return an object that contains all the header properties you want to pass to API request's header.
-    * Example: `{'Cache-Control': 'max-age=0', 'Content-Type': 'application/json'}` */
-   headers?(keyword:KeywordType, settings: SettingsType): Object,
-   /** Construct the API URL for scraping the data through your Scraper's API */
-   scrapeURL?(keyword:KeywordType, settings:SettingsType, countries:countryData, pagination?: ScraperPagination): string,
-   /** Custom function to extract the serp result from the scraped data. The extracted data should be @return {scraperExtractedItem[]} */
-   serpExtractor?(content:string): scraperExtractedItem[],
+  /** A Unique ID for the Scraper. eg: myScraper */
+  id: string;
+  /** The Name of the Scraper */
+  name: string;
+  /** The Website address of the Scraper */
+  website: string;
+  /** The result object's key that contains the results of the scraped data. For example,
+   * if your scraper API the data like this `{scraped:[item1,item2..]}` the resultObjectKey should be "scraped" */
+  resultObjectKey: string;
+  /** If the Scraper allows setting a precise location or allows city level scraping set this to true. */
+  allowsCity?: boolean;
+  /** Whether this scraper API handles its own pagination (e.g. num=100) and should bypass the app's pagination logic */
+  nativePagination?: boolean;
+  /** Set your own custom HTTP header properties when making the scraper API request.
+   * The function should return an object that contains all the header properties you want to pass to API request's header.
+   * Example: `{'Cache-Control': 'max-age=0', 'Content-Type': 'application/json'}` */
+  headers?(keyword: KeywordType, settings: SettingsType): Object;
+  /** Construct the API URL for scraping the data through your Scraper's API */
+  scrapeURL?(
+    keyword: KeywordType,
+    settings: SettingsType,
+    countries: countryData,
+    pagination?: ScraperPagination
+  ): string;
+  /** Optional fetch init overrides for scrapers that require POST bodies or custom request options. */
+  requestOptions?(
+    keyword: KeywordType,
+    settings: SettingsType,
+    countries: countryData,
+    pagination?: ScraperPagination
+  ): RequestInit;
+  /** Custom function to extract the serp result from the scraped data. The extracted data should be @return {scraperExtractedItem[]} */
+  serpExtractor?(content: string): scraperExtractedItem[];
 }

--- a/utils/scraper.ts
+++ b/utils/scraper.ts
@@ -1,29 +1,31 @@
-import axios, { AxiosResponse, CreateAxiosDefaults } from 'axios';
-import * as cheerio from 'cheerio';
-import { readFile, writeFile } from 'fs/promises';
-import HttpsProxyAgent from 'https-proxy-agent';
-import countries from './countries';
-import allScrapers from '../scrapers/index';
+import axios, { AxiosResponse, CreateAxiosDefaults } from "axios";
+import * as cheerio from "cheerio";
+import { readFile, writeFile } from "fs/promises";
+import HttpsProxyAgent from "https-proxy-agent";
+import countries from "./countries";
+import allScrapers from "../scrapers/index";
 
 type SearchResult = {
-   title: string,
-   url: string,
-   position: number,
-}
+  title: string;
+  url: string;
+  position: number;
+};
 
 type SERPObject = {
-   position:number,
-   url:string
-}
+  position: number;
+  url: string;
+};
 
-export type RefreshResult = false | {
-   ID: number,
-   keyword: string,
-   position:number,
-   url: string,
-   result: KeywordLastResult[],
-   error?: boolean | string
-}
+export type RefreshResult =
+  | false
+  | {
+      ID: number;
+      keyword: string;
+      position: number;
+      url: string;
+      result: KeywordLastResult[];
+      error?: boolean | string;
+    };
 
 const TOTAL_PAGES = 10;
 const PAGE_SIZE = 10;
@@ -37,129 +39,191 @@ const PAGE_SIZE = 10;
  * @returns {Promise}
  */
 export const getScraperClient = (
-   keyword:KeywordType,
-   settings:SettingsType,
-   scraper?: ScraperSettings,
-   pagination?: ScraperPagination,
-): Promise<AxiosResponse|Response> | false => {
-   let apiURL = ''; let client: Promise<AxiosResponse|Response> | false = false;
-   const headers: any = {
-      'Content-Type': 'application/json',
-      'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246',
-      Accept: 'application/json; charset=utf8;',
-   };
+  keyword: KeywordType,
+  settings: SettingsType,
+  scraper?: ScraperSettings,
+  pagination?: ScraperPagination
+): Promise<AxiosResponse | Response> | false => {
+  let apiURL = "";
+  let client: Promise<AxiosResponse | Response> | false = false;
+  const headers: any = {
+    "Content-Type": "application/json",
+    "User-Agent":
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246",
+    Accept: "application/json; charset=utf8;",
+  };
 
-   // eslint-disable-next-line max-len
-   const mobileAgent = 'Mozilla/5.0 (Linux; Android 10; SM-G996U Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Mobile Safari/537.36';
-   if (keyword && keyword.device === 'mobile') {
-      headers['User-Agent'] = mobileAgent;
-   }
+  // eslint-disable-next-line max-len
+  const mobileAgent =
+    "Mozilla/5.0 (Linux; Android 10; SM-G996U Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Mobile Safari/537.36";
+  if (keyword && keyword.device === "mobile") {
+    headers["User-Agent"] = mobileAgent;
+  }
 
-   if (scraper) {
-      // Set Scraper Header
-      const scrapeHeaders = scraper.headers ? scraper.headers(keyword, settings) : null;
-      const scraperApiUrl = scraper.scrapeURL ? scraper.scrapeURL(keyword, settings, countries, pagination) : null;
-      if (scrapeHeaders && Object.keys(scrapeHeaders).length > 0) {
-         Object.keys(scrapeHeaders).forEach((headerItemKey:string) => {
-            headers[headerItemKey] = scrapeHeaders[headerItemKey as keyof object];
-         });
-      }
-      // Set Scraper API URL
-      // If not URL is generated, stop right here.
-      if (scraperApiUrl) {
-         apiURL = scraperApiUrl;
-      } else {
-         return false;
-      }
-   }
+  if (scraper) {
+    // Set Scraper Header
+    const scrapeHeaders = scraper.headers
+      ? scraper.headers(keyword, settings)
+      : null;
+    const scraperApiUrl = scraper.scrapeURL
+      ? scraper.scrapeURL(keyword, settings, countries, pagination)
+      : null;
+    if (scrapeHeaders && Object.keys(scrapeHeaders).length > 0) {
+      Object.keys(scrapeHeaders).forEach((headerItemKey: string) => {
+        headers[headerItemKey] = scrapeHeaders[headerItemKey as keyof object];
+      });
+    }
+    // Set Scraper API URL
+    // If not URL is generated, stop right here.
+    if (scraperApiUrl) {
+      apiURL = scraperApiUrl;
+    } else {
+      return false;
+    }
+  }
 
-   if (settings && settings.scraper_type === 'proxy' && settings.proxy) {
-      const axiosConfig: CreateAxiosDefaults = {};
-      headers.Accept = 'gzip,deflate,compress;';
-      axiosConfig.headers = headers;
-      const proxies = settings.proxy.split(/\r?\n|\r|\n/g);
-      let proxyURL = '';
-      if (proxies.length > 1) {
-         proxyURL = proxies[Math.floor(Math.random() * proxies.length)];
-      } else {
-         const [firstProxy] = proxies;
-         proxyURL = firstProxy;
-      }
+  if (settings && settings.scraper_type === "proxy" && settings.proxy) {
+    const axiosConfig: CreateAxiosDefaults = {};
+    headers.Accept = "gzip,deflate,compress;";
+    axiosConfig.headers = headers;
+    const proxies = settings.proxy.split(/\r?\n|\r|\n/g);
+    let proxyURL = "";
+    if (proxies.length > 1) {
+      proxyURL = proxies[Math.floor(Math.random() * proxies.length)];
+    } else {
+      const [firstProxy] = proxies;
+      proxyURL = firstProxy;
+    }
 
-      axiosConfig.httpsAgent = new (HttpsProxyAgent as any)(proxyURL.trim());
-      axiosConfig.proxy = false;
-      const axiosClient = axios.create(axiosConfig);
-      const p = pagination || { start: 0, num: PAGE_SIZE };
-      client = axiosClient.get(`https://www.google.com/search?num=${p.num}&start=${p.start}&q=${encodeURI(keyword.keyword)}`);
-   } else {
-      client = fetch(apiURL, { method: 'GET', headers });
-   }
+    axiosConfig.httpsAgent = new (HttpsProxyAgent as any)(proxyURL.trim());
+    axiosConfig.proxy = false;
+    const axiosClient = axios.create(axiosConfig);
+    const p = pagination || { start: 0, num: PAGE_SIZE };
+    client = axiosClient.get(
+      `https://www.google.com/search?num=${p.num}&start=${
+        p.start
+      }&q=${encodeURI(keyword.keyword)}`
+    );
+  } else {
+    const requestOptions = scraper?.requestOptions
+      ? scraper.requestOptions(keyword, settings, countries, pagination)
+      : {};
+    client = fetch(apiURL, {
+      method: "GET",
+      ...requestOptions,
+      headers: {
+        ...headers,
+        ...(requestOptions.headers || {}),
+      },
+    });
+  }
 
-   return client;
+  return client;
 };
 
 /**
  * Scrape a single page of Google Search results with absolute position offsets applied.
  */
 const scrapeSinglePage = async (
-   keyword: KeywordType,
-   settings: SettingsType,
-   scraperObj: ScraperSettings | undefined,
-   pagination: ScraperPagination,
+  keyword: KeywordType,
+  settings: SettingsType,
+  scraperObj: ScraperSettings | undefined,
+  pagination: ScraperPagination
 ): Promise<SearchResult[]> => {
-   const scraperType = settings?.scraper_type || '';
-   const scraperClient = getScraperClient(keyword, settings, scraperObj, pagination);
-   if (!scraperClient) { return []; }
-   try {
-      const res = scraperType === 'proxy' && settings.proxy ? await scraperClient : await scraperClient.then((result:any) => result.json());
-      const scraperResult = scraperObj?.resultObjectKey && res[scraperObj.resultObjectKey] ? res[scraperObj.resultObjectKey] : '';
-      const scrapeResult: string = (res.data || res.html || res.results || scraperResult || '');
-      if (res && scrapeResult) {
-         const extracted = scraperObj?.serpExtractor ? scraperObj.serpExtractor(scrapeResult) : extractScrapedResult(scrapeResult, keyword.device);
-         return extracted.map((item, i) => ({ ...item, position: pagination.start + i + 1 }));
-      }
-   } catch (error:any) {
-      console.log('[ERROR] Scraping page', pagination.page, 'for keyword:', keyword.keyword, error?.message || '');
-   }
-   return [];
+  const scraperType = settings?.scraper_type || "";
+  const scraperClient = getScraperClient(
+    keyword,
+    settings,
+    scraperObj,
+    pagination
+  );
+  if (!scraperClient) {
+    return [];
+  }
+  try {
+    const res =
+      scraperType === "proxy" && settings.proxy
+        ? await scraperClient
+        : await scraperClient.then((result: any) => result.json());
+    const scraperResult =
+      scraperObj?.resultObjectKey && res[scraperObj.resultObjectKey]
+        ? res[scraperObj.resultObjectKey]
+        : "";
+    const scrapeResult: string =
+      res.data || res.html || res.results || scraperResult || "";
+    if (res && scrapeResult) {
+      const extracted = scraperObj?.serpExtractor
+        ? scraperObj.serpExtractor(scrapeResult)
+        : extractScrapedResult(scrapeResult, keyword.device);
+      return extracted.map((item, i) => ({
+        ...item,
+        position: pagination.start + i + 1,
+      }));
+    }
+  } catch (error: any) {
+    console.log(
+      "[ERROR] Scraping page",
+      pagination.page,
+      "for keyword:",
+      keyword.keyword,
+      error?.message || ""
+    );
+  }
+  return [];
 };
 
 /**
  * Build a 100-position result array: scraped positions keep their data, unscraped positions are marked skipped.
  */
-const buildFullResults = (scrapedResults: SearchResult[], totalPositions: number = TOTAL_PAGES * PAGE_SIZE): KeywordLastResult[] => {
-   const scrapedByPos = new Map(scrapedResults.map((r) => [r.position, r]));
-   const full: KeywordLastResult[] = [];
-   for (let i = 1; i <= totalPositions; i += 1) {
-      const found = scrapedByPos.get(i);
-      full.push(found ? { position: i, url: found.url, title: found.title } : { position: i, url: '', title: '', skipped: true });
-   }
-   return full;
+const buildFullResults = (
+  scrapedResults: SearchResult[],
+  totalPositions: number = TOTAL_PAGES * PAGE_SIZE
+): KeywordLastResult[] => {
+  const scrapedByPos = new Map(scrapedResults.map((r) => [r.position, r]));
+  const full: KeywordLastResult[] = [];
+  for (let i = 1; i <= totalPositions; i += 1) {
+    const found = scrapedByPos.get(i);
+    full.push(
+      found
+        ? { position: i, url: found.url, title: found.title }
+        : { position: i, url: "", title: "", skipped: true }
+    );
+  }
+  return full;
 };
 
 /**
  * Resolve effective scrape strategy from domain-level overrides or global settings.
  */
 const resolveStrategy = (
-   settings: SettingsType,
-   domainSettings?: Partial<DomainType>,
-): { strategy: ScrapeStrategy, paginationLimit: number, smartFullFallback: boolean } => {
-   const domainStrategy = domainSettings?.scrape_strategy;
+  settings: SettingsType,
+  domainSettings?: Partial<DomainType>
+): {
+  strategy: ScrapeStrategy;
+  paginationLimit: number;
+  smartFullFallback: boolean;
+} => {
+  const domainStrategy = domainSettings?.scrape_strategy;
 
-   // If no domain-level strategy override is set, use global settings for everything.
-   if (!domainStrategy) {
-      return {
-         strategy: (settings.scrape_strategy || 'basic') as ScrapeStrategy,
-         paginationLimit: settings.scrape_pagination_limit || 5,
-         smartFullFallback: settings.scrape_smart_full_fallback || false,
-      };
-   }
+  // If no domain-level strategy override is set, use global settings for everything.
+  if (!domainStrategy) {
+    return {
+      strategy: (settings.scrape_strategy || "basic") as ScrapeStrategy,
+      paginationLimit: settings.scrape_pagination_limit || 5,
+      smartFullFallback: settings.scrape_smart_full_fallback || false,
+    };
+  }
 
-   // Domain override is active — use domain values, fall back to global for unset fields.
-   const strategy: ScrapeStrategy = domainStrategy as ScrapeStrategy;
-   const paginationLimit: number = domainSettings?.scrape_pagination_limit || settings.scrape_pagination_limit || 5;
-   const smartFullFallback: boolean = domainSettings?.scrape_smart_full_fallback ?? (settings.scrape_smart_full_fallback || false);
-   return { strategy, paginationLimit, smartFullFallback };
+  // Domain override is active — use domain values, fall back to global for unset fields.
+  const strategy: ScrapeStrategy = domainStrategy as ScrapeStrategy;
+  const paginationLimit: number =
+    domainSettings?.scrape_pagination_limit ||
+    settings.scrape_pagination_limit ||
+    5;
+  const smartFullFallback: boolean =
+    domainSettings?.scrape_smart_full_fallback ??
+    (settings.scrape_smart_full_fallback || false);
+  return { strategy, paginationLimit, smartFullFallback };
 };
 
 /**
@@ -171,78 +235,118 @@ const resolveStrategy = (
  * @returns {RefreshResult}
  */
 export const scrapeKeywordWithStrategy = async (
-   keyword: KeywordType,
-   settings: SettingsType,
-   domainSettings?: Partial<DomainType>,
+  keyword: KeywordType,
+  settings: SettingsType,
+  domainSettings?: Partial<DomainType>
 ): Promise<RefreshResult> => {
-   const scraperType = settings?.scraper_type || '';
-   const scraperObj = allScrapers.find((s: ScraperSettings) => s.id === scraperType);
+  const scraperType = settings?.scraper_type || "";
+  const scraperObj = allScrapers.find(
+    (s: ScraperSettings) => s.id === scraperType
+  );
 
-   const errorResult: RefreshResult = {
-      ID: keyword.ID,
-      keyword: keyword.keyword,
-      position: keyword.position,
-      url: keyword.url,
-      result: keyword.lastResult,
-      error: true,
-   };
+  const errorResult: RefreshResult = {
+    ID: keyword.ID,
+    keyword: keyword.keyword,
+    position: keyword.position,
+    url: keyword.url,
+    result: keyword.lastResult,
+    error: true,
+  };
 
-   // Native-pagination scrapers (serpapi, searchapi) fetch 100 results in one request
-   if (scraperObj?.nativePagination) {
-      return scrapeKeywordFromGoogle(keyword, settings);
-   }
+  // Native-pagination scrapers (serpapi, searchapi) fetch 100 results in one request
+  if (scraperObj?.nativePagination) {
+    return scrapeKeywordFromGoogle(keyword, settings);
+  }
 
-   const { strategy, paginationLimit, smartFullFallback } = resolveStrategy(settings, domainSettings);
-   let pagesToScrape: number[];
+  const { strategy, paginationLimit, smartFullFallback } = resolveStrategy(
+    settings,
+    domainSettings
+  );
+  let pagesToScrape: number[];
 
-   if (strategy === 'custom') {
-      const limit = Math.max(1, Math.min(paginationLimit, TOTAL_PAGES));
-      pagesToScrape = Array.from({ length: limit }, (_, i) => i + 1);
-   } else if (strategy === 'smart') {
-      const lastPos = keyword.position;
-      const lastPage = lastPos > 0 ? Math.ceil(lastPos / PAGE_SIZE) : 1;
-      const neighbors = [lastPage - 1, lastPage, lastPage + 1].filter((p) => p >= 1 && p <= TOTAL_PAGES);
-      pagesToScrape = [...new Set(neighbors)];
-   } else {
-      pagesToScrape = [1]; // Basic: first page only
-   }
+  if (strategy === "custom") {
+    const limit = Math.max(1, Math.min(paginationLimit, TOTAL_PAGES));
+    pagesToScrape = Array.from({ length: limit }, (_, i) => i + 1);
+  } else if (strategy === "smart") {
+    const lastPos = keyword.position;
+    const lastPage = lastPos > 0 ? Math.ceil(lastPos / PAGE_SIZE) : 1;
+    const neighbors = [lastPage - 1, lastPage, lastPage + 1].filter(
+      (p) => p >= 1 && p <= TOTAL_PAGES
+    );
+    pagesToScrape = [...new Set(neighbors)];
+  } else {
+    pagesToScrape = [1]; // Basic: first page only
+  }
 
-   const allScrapedResults: SearchResult[] = [];
-   for (const pageNum of pagesToScrape) {
-      const pagination: ScraperPagination = { start: (pageNum - 1) * PAGE_SIZE, num: PAGE_SIZE, page: pageNum };
-      // eslint-disable-next-line no-await-in-loop
-      const pageResults = await scrapeSinglePage(keyword, settings, scraperObj, pagination);
-      if (pageResults.length > 0) { allScrapedResults.push(...pageResults); }
-   }
+  const allScrapedResults: SearchResult[] = [];
+  for (const pageNum of pagesToScrape) {
+    const pagination: ScraperPagination = {
+      start: (pageNum - 1) * PAGE_SIZE,
+      num: PAGE_SIZE,
+      page: pageNum,
+    };
+    // eslint-disable-next-line no-await-in-loop
+    const pageResults = await scrapeSinglePage(
+      keyword,
+      settings,
+      scraperObj,
+      pagination
+    );
+    if (pageResults.length > 0) {
+      allScrapedResults.push(...pageResults);
+    }
+  }
 
-   if (allScrapedResults.length === 0) { return errorResult; }
-   // Smart + full fallback: if domain not found on neighboring pages, scrape the rest
-   if (strategy === 'smart' && smartFullFallback) {
-      const serpCheck = getSerp(keyword.domain, allScrapedResults);
-      if (serpCheck.position === 0) {
-         const alreadyScraped = new Set(pagesToScrape);
-         const remainingPages = Array.from({ length: TOTAL_PAGES }, (_, i) => i + 1).filter((p) => !alreadyScraped.has(p));
-         for (const pageNum of remainingPages) {
-            const pagination: ScraperPagination = { start: (pageNum - 1) * PAGE_SIZE, num: PAGE_SIZE, page: pageNum };
-            // eslint-disable-next-line no-await-in-loop
-            const pageResults = await scrapeSinglePage(keyword, settings, scraperObj, pagination);
-            if (pageResults.length > 0) { allScrapedResults.push(...pageResults); }
-         }
+  if (allScrapedResults.length === 0) {
+    return errorResult;
+  }
+  // Smart + full fallback: if domain not found on neighboring pages, scrape the rest
+  if (strategy === "smart" && smartFullFallback) {
+    const serpCheck = getSerp(keyword.domain, allScrapedResults);
+    if (serpCheck.position === 0) {
+      const alreadyScraped = new Set(pagesToScrape);
+      const remainingPages = Array.from(
+        { length: TOTAL_PAGES },
+        (_, i) => i + 1
+      ).filter((p) => !alreadyScraped.has(p));
+      for (const pageNum of remainingPages) {
+        const pagination: ScraperPagination = {
+          start: (pageNum - 1) * PAGE_SIZE,
+          num: PAGE_SIZE,
+          page: pageNum,
+        };
+        // eslint-disable-next-line no-await-in-loop
+        const pageResults = await scrapeSinglePage(
+          keyword,
+          settings,
+          scraperObj,
+          pagination
+        );
+        if (pageResults.length > 0) {
+          allScrapedResults.push(...pageResults);
+        }
       }
-   }
+    }
+  }
 
-   const finalSerp = getSerp(keyword.domain, allScrapedResults);
-   const fullResults = buildFullResults(allScrapedResults);
+  const finalSerp = getSerp(keyword.domain, allScrapedResults);
+  const fullResults = buildFullResults(allScrapedResults);
 
-   console.log('[SERP]:', keyword.keyword, finalSerp.position, finalSerp.url, `(strategy: ${strategy})`);
-   return {
-      ID: keyword.ID,
-      keyword: keyword.keyword,
-      position: finalSerp.position,
-      url: finalSerp.url,
-      result: fullResults,
-      error: false,
-   };
+  console.log(
+    "[SERP]:",
+    keyword.keyword,
+    finalSerp.position,
+    finalSerp.url,
+    `(strategy: ${strategy})`
+  );
+  return {
+    ID: keyword.ID,
+    keyword: keyword.keyword,
+    position: finalSerp.position,
+    url: finalSerp.url,
+    result: fullResults,
+    error: false,
+  };
 };
 
 /**
@@ -252,54 +356,94 @@ export const scrapeKeywordWithStrategy = async (
  * @param {SettingsType} settings - the App Settings
  * @returns {RefreshResult}
  */
-export const scrapeKeywordFromGoogle = async (keyword:KeywordType, settings:SettingsType) : Promise<RefreshResult> => {
-   let refreshedResults:RefreshResult = {
-      ID: keyword.ID,
-      keyword: keyword.keyword,
-      position: keyword.position,
-      url: keyword.url,
-      result: keyword.lastResult,
-      error: true,
-   };
-   const scraperType = settings?.scraper_type || '';
-   const scraperObj = allScrapers.find((scraper:ScraperSettings) => scraper.id === scraperType);
-   const nativePagination: ScraperPagination = { start: 0, num: 100, page: 1 };
-   const scraperClient = getScraperClient(keyword, settings, scraperObj, nativePagination);
+export const scrapeKeywordFromGoogle = async (
+  keyword: KeywordType,
+  settings: SettingsType
+): Promise<RefreshResult> => {
+  let refreshedResults: RefreshResult = {
+    ID: keyword.ID,
+    keyword: keyword.keyword,
+    position: keyword.position,
+    url: keyword.url,
+    result: keyword.lastResult,
+    error: true,
+  };
+  const scraperType = settings?.scraper_type || "";
+  const scraperObj = allScrapers.find(
+    (scraper: ScraperSettings) => scraper.id === scraperType
+  );
+  const nativePagination: ScraperPagination = { start: 0, num: 100, page: 1 };
+  const scraperClient = getScraperClient(
+    keyword,
+    settings,
+    scraperObj,
+    nativePagination
+  );
 
-   if (!scraperClient) { return false; }
+  if (!scraperClient) {
+    return false;
+  }
 
-   let scraperError:any = null;
-   try {
-      const res = scraperType === 'proxy' && settings.proxy ? await scraperClient : await scraperClient.then((result:any) => result.json());
-      const scraperResult = scraperObj?.resultObjectKey && res[scraperObj.resultObjectKey] ? res[scraperObj.resultObjectKey] : '';
-      const scrapeResult:string = (res.data || res.html || res.results || scraperResult || '');
-      if (res && scrapeResult) {
-         const extracted = scraperObj?.serpExtractor ? scraperObj.serpExtractor(scrapeResult) : extractScrapedResult(scrapeResult, keyword.device);
-         await writeFile('result.txt', JSON.stringify(scrapeResult), { encoding: 'utf-8' }).catch((err) => { console.log(err); });
-         const serp = getSerp(keyword.domain, extracted);
-         refreshedResults = { ID: keyword.ID, keyword: keyword.keyword, position: serp.position, url: serp.url, result: extracted, error: false };
-         console.log('[SERP]: ', keyword.keyword, serp.position, serp.url);
-      } else {
-         scraperError = res.detail || res.error || 'Unknown Error';
-         throw new Error(res);
-      }
-   } catch (error:any) {
-      refreshedResults.error = scraperError || 'Unknown Error';
-      if (settings.scraper_type === 'proxy' && error && error.response && error.response.statusText) {
-         refreshedResults.error = `[${error.response.status}] ${error.response.statusText}`;
-      } else if (settings.scraper_type === 'proxy' && error) {
-         refreshedResults.error = error;
-      }
+  let scraperError: any = null;
+  try {
+    const res =
+      scraperType === "proxy" && settings.proxy
+        ? await scraperClient
+        : await scraperClient.then((result: any) => result.json());
+    const scraperResult =
+      scraperObj?.resultObjectKey && res[scraperObj.resultObjectKey]
+        ? res[scraperObj.resultObjectKey]
+        : "";
+    const scrapeResult: string =
+      res.data || res.html || res.results || scraperResult || "";
+    if (res && scrapeResult) {
+      const extracted = scraperObj?.serpExtractor
+        ? scraperObj.serpExtractor(scrapeResult)
+        : extractScrapedResult(scrapeResult, keyword.device);
+      await writeFile("result.txt", JSON.stringify(scrapeResult), {
+        encoding: "utf-8",
+      }).catch((err) => {
+        console.log(err);
+      });
+      const serp = getSerp(keyword.domain, extracted);
+      refreshedResults = {
+        ID: keyword.ID,
+        keyword: keyword.keyword,
+        position: serp.position,
+        url: serp.url,
+        result: extracted,
+        error: false,
+      };
+      console.log("[SERP]: ", keyword.keyword, serp.position, serp.url);
+    } else {
+      scraperError = res.detail || res.error || "Unknown Error";
+      throw new Error(res);
+    }
+  } catch (error: any) {
+    refreshedResults.error = scraperError || "Unknown Error";
+    if (
+      settings.scraper_type === "proxy" &&
+      error &&
+      error.response &&
+      error.response.statusText
+    ) {
+      refreshedResults.error = `[${error.response.status}] ${error.response.statusText}`;
+    } else if (settings.scraper_type === "proxy" && error) {
+      refreshedResults.error = error;
+    }
 
-      console.log('[ERROR] Scraping Keyword : ', keyword.keyword);
-      if (!(error && error.response && error.response.statusText)) {
-         console.log('[ERROR_MESSAGE]: ', JSON.stringify(error));
-      } else {
-         console.log('[ERROR_MESSAGE]: ', error && error.response && error.response.statusText);
-      }
-   }
+    console.log("[ERROR] Scraping Keyword : ", keyword.keyword);
+    if (!(error && error.response && error.response.statusText)) {
+      console.log("[ERROR_MESSAGE]: ", JSON.stringify(error));
+    } else {
+      console.log(
+        "[ERROR_MESSAGE]: ",
+        error && error.response && error.response.statusText
+      );
+    }
+  }
 
-   return refreshedResults;
+  return refreshedResults;
 };
 
 /**
@@ -308,68 +452,79 @@ export const scrapeKeywordFromGoogle = async (keyword:KeywordType, settings:Sett
  * @param {string} device - The device of the keyword.
  * @returns {SearchResult[]}
  */
-export const extractScrapedResult = (content: string, device: string): SearchResult[] => {
-   const extractedResult = [];
+export const extractScrapedResult = (
+  content: string,
+  device: string
+): SearchResult[] => {
+  const extractedResult = [];
 
-   const $ = cheerio.load(content);
-   const hasValidContent = [...$('body').find('#search'), ...$('body').find('#rso')];
-   if (hasValidContent.length === 0) {
-      const msg = '[ERROR] Scraped search results do not adhere to expected format. Unable to parse results';
-      console.log(msg);
-      throw new Error(msg);
-   }
+  const $ = cheerio.load(content);
+  const hasValidContent = [
+    ...$("body").find("#search"),
+    ...$("body").find("#rso"),
+  ];
+  if (hasValidContent.length === 0) {
+    const msg =
+      "[ERROR] Scraped search results do not adhere to expected format. Unable to parse results";
+    console.log(msg);
+    throw new Error(msg);
+  }
 
-   // Desktop: try #search > div > div + h3 (classic layout)
-   const hasNumberOfResult = $('body').find('#search  > div > div');
-   const searchResultItems = hasNumberOfResult.find('h3');
-   let lastPosition = 0;
+  // Desktop: try #search > div > div + h3 (classic layout)
+  const hasNumberOfResult = $("body").find("#search  > div > div");
+  const searchResultItems = hasNumberOfResult.find("h3");
+  let lastPosition = 0;
 
-   for (let i = 0; i < searchResultItems.length; i += 1) {
-      if (searchResultItems[i]) {
-         const title = $(searchResultItems[i]).html();
-         const url = $(searchResultItems[i]).closest('a').attr('href');
-         if (title && url) {
-            lastPosition += 1;
-            extractedResult.push({ title, url, position: lastPosition });
-         }
+  for (let i = 0; i < searchResultItems.length; i += 1) {
+    if (searchResultItems[i]) {
+      const title = $(searchResultItems[i]).html();
+      const url = $(searchResultItems[i]).closest("a").attr("href");
+      if (title && url) {
+        lastPosition += 1;
+        extractedResult.push({ title, url, position: lastPosition });
       }
-   }
+    }
+  }
 
-   // Desktop fallback: #rso with [role="heading"] (newer Google layout — no h3, no #search)
-   if (extractedResult.length === 0) {
-      const rsoHeadings = $('body').find('#rso [role="heading"]');
-      for (let i = 0; i < rsoHeadings.length; i += 1) {
-         const heading = $(rsoHeadings[i]);
-         const title = heading.text();
-         const url = heading.closest('a').attr('href');
-         if (title && url && url.startsWith('http')) {
-            lastPosition += 1;
-            extractedResult.push({ title, url, position: lastPosition });
-         }
+  // Desktop fallback: #rso with [role="heading"] (newer Google layout — no h3, no #search)
+  if (extractedResult.length === 0) {
+    const rsoHeadings = $("body").find('#rso [role="heading"]');
+    for (let i = 0; i < rsoHeadings.length; i += 1) {
+      const heading = $(rsoHeadings[i]);
+      const title = heading.text();
+      const url = heading.closest("a").attr("href");
+      if (title && url && url.startsWith("http")) {
+        lastPosition += 1;
+        extractedResult.push({ title, url, position: lastPosition });
       }
-   }
+    }
+  }
 
-   // Mobile Scraper
-   if (extractedResult.length === 0 && device === 'mobile') {
-      const items = $('body').find('#rso > div');
-      console.log('Scraped search results contain ', items.length, ' mobile results.');
-      for (let i = 0; i < items.length; i += 1) {
-         const item = $(items[i]);
-         const linkDom = item.find('a[role="presentation"]');
-         if (linkDom) {
-            const url = linkDom.attr('href');
-            const titleDom = linkDom.find('[role="link"]');
-            const title = titleDom ? titleDom.text() : '';
-            if (title && url) {
-               lastPosition += 1;
-               extractedResult.push({ title, url, position: lastPosition });
-            }
-         }
+  // Mobile Scraper
+  if (extractedResult.length === 0 && device === "mobile") {
+    const items = $("body").find("#rso > div");
+    console.log(
+      "Scraped search results contain ",
+      items.length,
+      " mobile results."
+    );
+    for (let i = 0; i < items.length; i += 1) {
+      const item = $(items[i]);
+      const linkDom = item.find('a[role="presentation"]');
+      if (linkDom) {
+        const url = linkDom.attr("href");
+        const titleDom = linkDom.find('[role="link"]');
+        const title = titleDom ? titleDom.text() : "";
+        if (title && url) {
+          lastPosition += 1;
+          extractedResult.push({ title, url, position: lastPosition });
+        }
       }
-   }
-   // console.log('Scraped search results count: ', extractedResult.length);
+    }
+  }
+  // console.log('Scraped search results count: ', extractedResult.length);
 
-   return extractedResult;
+  return extractedResult;
 };
 
 /**
@@ -378,20 +533,38 @@ export const extractScrapedResult = (content: string, device: string): SearchRes
  * @param {SearchResult[]} result - The search result array extracted from the Google Search result.
  * @returns {SERPObject}
  */
-export const getSerp = (domainURL:string, result:SearchResult[]) : SERPObject => {
-   if (result.length === 0 || !domainURL) { return { position: 0, url: '' }; }
-   const URLToFind = new URL(domainURL.includes('https://') ? domainURL : `https://${domainURL}`);
-   const isURL = URLToFind.pathname !== '/';
-   const stripWww = (hostname: string) => hostname.replace(/^www\./, '');
-   const foundItem = result.find((item) => {
-      if (!item.url) { return false; }
-      const itemURL = new URL(item.url.includes('https://') ? item.url : `https://${item.url}`);
-      if (isURL && `${stripWww(URLToFind.hostname)}${URLToFind.pathname}/` === stripWww(itemURL.hostname) + itemURL.pathname) {
-         return true;
-      }
-      return stripWww(URLToFind.hostname) === stripWww(itemURL.hostname);
-   });
-   return { position: foundItem ? foundItem.position : 0, url: foundItem && foundItem.url ? foundItem.url : '' };
+export const getSerp = (
+  domainURL: string,
+  result: SearchResult[]
+): SERPObject => {
+  if (result.length === 0 || !domainURL) {
+    return { position: 0, url: "" };
+  }
+  const URLToFind = new URL(
+    domainURL.includes("https://") ? domainURL : `https://${domainURL}`
+  );
+  const isURL = URLToFind.pathname !== "/";
+  const stripWww = (hostname: string) => hostname.replace(/^www\./, "");
+  const foundItem = result.find((item) => {
+    if (!item.url) {
+      return false;
+    }
+    const itemURL = new URL(
+      item.url.includes("https://") ? item.url : `https://${item.url}`
+    );
+    if (
+      isURL &&
+      `${stripWww(URLToFind.hostname)}${URLToFind.pathname}/` ===
+        stripWww(itemURL.hostname) + itemURL.pathname
+    ) {
+      return true;
+    }
+    return stripWww(URLToFind.hostname) === stripWww(itemURL.hostname);
+  });
+  return {
+    position: foundItem ? foundItem.position : 0,
+    url: foundItem && foundItem.url ? foundItem.url : "",
+  };
 };
 
 /**
@@ -400,19 +573,31 @@ export const getSerp = (domainURL:string, result:SearchResult[]) : SERPObject =>
  * @param {string} keywordID - The keywordID of the failed Keyword Scrape.
  * @returns {void}
  */
-export const retryScrape = async (keywordID: number) : Promise<void> => {
-   if (!keywordID && !Number.isInteger(keywordID)) { return; }
-   let currentQueue: number[] = [];
+export const retryScrape = async (keywordID: number): Promise<void> => {
+  if (!keywordID && !Number.isInteger(keywordID)) {
+    return;
+  }
+  let currentQueue: number[] = [];
 
-   const filePath = `${process.cwd()}/data/failed_queue.json`;
-   const currentQueueRaw = await readFile(filePath, { encoding: 'utf-8' }).catch((err) => { console.log(err); return '[]'; });
-   currentQueue = currentQueueRaw ? JSON.parse(currentQueueRaw) : [];
+  const filePath = `${process.cwd()}/data/failed_queue.json`;
+  const currentQueueRaw = await readFile(filePath, { encoding: "utf-8" }).catch(
+    (err) => {
+      console.log(err);
+      return "[]";
+    }
+  );
+  currentQueue = currentQueueRaw ? JSON.parse(currentQueueRaw) : [];
 
-   if (!currentQueue.includes(keywordID)) {
-      currentQueue.push(Math.abs(keywordID));
-   }
+  if (!currentQueue.includes(keywordID)) {
+    currentQueue.push(Math.abs(keywordID));
+  }
 
-   await writeFile(filePath, JSON.stringify(currentQueue), { encoding: 'utf-8' }).catch((err) => { console.log(err); return '[]'; });
+  await writeFile(filePath, JSON.stringify(currentQueue), {
+    encoding: "utf-8",
+  }).catch((err) => {
+    console.log(err);
+    return "[]";
+  });
 };
 
 /**
@@ -420,14 +605,28 @@ export const retryScrape = async (keywordID: number) : Promise<void> => {
  * @param {string} keywordID - The keywordID of the failed Keyword Scrape.
  * @returns {void}
  */
-export const removeFromRetryQueue = async (keywordID: number) : Promise<void> => {
-   if (!keywordID && !Number.isInteger(keywordID)) { return; }
-   let currentQueue: number[] = [];
+export const removeFromRetryQueue = async (
+  keywordID: number
+): Promise<void> => {
+  if (!keywordID && !Number.isInteger(keywordID)) {
+    return;
+  }
+  let currentQueue: number[] = [];
 
-   const filePath = `${process.cwd()}/data/failed_queue.json`;
-   const currentQueueRaw = await readFile(filePath, { encoding: 'utf-8' }).catch((err) => { console.log(err); return '[]'; });
-   currentQueue = currentQueueRaw ? JSON.parse(currentQueueRaw) : [];
-   currentQueue = currentQueue.filter((item) => item !== Math.abs(keywordID));
+  const filePath = `${process.cwd()}/data/failed_queue.json`;
+  const currentQueueRaw = await readFile(filePath, { encoding: "utf-8" }).catch(
+    (err) => {
+      console.log(err);
+      return "[]";
+    }
+  );
+  currentQueue = currentQueueRaw ? JSON.parse(currentQueueRaw) : [];
+  currentQueue = currentQueue.filter((item) => item !== Math.abs(keywordID));
 
-   await writeFile(filePath, JSON.stringify(currentQueue), { encoding: 'utf-8' }).catch((err) => { console.log(err); return '[]'; });
+  await writeFile(filePath, JSON.stringify(currentQueue), {
+    encoding: "utf-8",
+  }).catch((err) => {
+    console.log(err);
+    return "[]";
+  });
 };


### PR DESCRIPTION
## Summary
- switch the ScrapingRobot integration to the current POST-based API flow using the `HtmlRequestScraper` module
- add per-scraper request options so providers can override the default fetch method and body without affecting other scrapers
- verify the ferrycenter keyword refresh succeeds again in the local dev environment and clears the previous update error